### PR TITLE
docs: add missing hook in validation.md for "Dynamic validation groups"

### DIFF
--- a/core/validation.md
+++ b/core/validation.md
@@ -208,7 +208,7 @@ use ApiPlatform\Metadata\ApiResource;
 use Symfony\Component\Validator\Constraints as Assert;
 
 #[ApiResource(
-    validationContext: ['groups' => [Book::class, 'validationGroups']
+    validationContext: ['groups' => [Book::class, 'validationGroups']]
 )]
 class Book
 {


### PR DESCRIPTION
There is a missing hook in the documentation on the validation part for the paragraph: Dynamic validation groups
